### PR TITLE
fix: use numeric client ID for journey pages

### DIFF
--- a/app/actions/journey-actions.ts
+++ b/app/actions/journey-actions.ts
@@ -217,8 +217,10 @@ export async function updateJourneyPageStatus(
 /**
  * Gets all journey pages for a client, ordered by page_order
  */
+// Fetch all journey pages for a given client
+// Use numeric client IDs to match the database schema
 export async function getClientJourneyPages(
-  clientId: string
+  clientId: number
 ): Promise<{ success: boolean; error?: string; pages?: JourneyPage[] }> {
   try {
     const { data, error } = await supabaseServer


### PR DESCRIPTION
## Summary
- ensure getClientJourneyPages uses numeric client IDs to align with database expectations

## Testing
- `pnpm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_b_68bc97188f04832eb5462ee380c642da